### PR TITLE
Hotfix for card image sizing and typo in post detail.

### DIFF
--- a/components/DeleteCard.jsx
+++ b/components/DeleteCard.jsx
@@ -63,7 +63,7 @@ const DeleteCard = ({
   return (
     <div className="w-full h-75 rounded-lg shadow-md overflow-hidden hover:scale-105 duration-300">
       <img
-        className="object-cover w-full h-full"
+        className="object-cover w-full h-48"
         src={imageUrl}
         alt="Apartment"
       />

--- a/components/card/Card.jsx
+++ b/components/card/Card.jsx
@@ -1,17 +1,10 @@
 import React from "react";
 
-const Card = ({
-  address,
-  bedrooms,
-  bathrooms,
-  price,
-  imageUrl,
-  season,
-}) => {
+const Card = ({ address, bedrooms, bathrooms, price, imageUrl, season }) => {
   return (
-    <div className="w-full h-75 rounded-lg shadow-md overflow-hidden hover:scale-105">
+    <div className="w-full h-75 rounded-lg shadow-md overflow-hidden hover:scale-105 duration-500">
       <img
-        className="object-cover w-full h-full"
+        className="object-cover w-full h-48"
         src={imageUrl}
         alt="Apartment"
       />

--- a/components/post/Post.jsx
+++ b/components/post/Post.jsx
@@ -55,7 +55,7 @@ const Post = ({
               <p className="font-medium text-stone-600">{squareFeet} sq feet</p>
             </div>
             <div className="text-black border-slate-400 p-6">
-              Roomates
+              Roommates
               <p className="font-medium text-stone-600">{roomates}</p>
             </div>
           </div>


### PR DESCRIPTION
For the card component, the image sizes were having issues and rendering differently for images with different aspect ratios. In the new patch, I added a static height to 48pt, which will allow for all of the images to stay the same size.

In the post detail component, I caught a spelling error in the word "roommates" and fixed it.